### PR TITLE
Set manual_seed from CLI

### DIFF
--- a/ribodetector/detect.py
+++ b/ribodetector/detect.py
@@ -806,7 +806,7 @@ none: give label based on the mean probability of read pair.
     else:
         config_file = args.config
     config = ConfigParser.from_json(config_file)
-    if args.seed:
+    if isinstance(args.seed, int):
         torch.manual_seed(args.seed)
 
     seq_pred = Predictor(config, args)

--- a/ribodetector/detect.py
+++ b/ribodetector/detect.py
@@ -785,6 +785,8 @@ none: give label based on the mean probability of read pair.
 
     args.add_argument('-t', '--threads', default=10, type=int,
                       help='Number of threads to use. (default: 10)')
+    args.add_argument('-s', '--seed', default=None, type=int,
+                      help='Random seed.')
     args.add_argument('-m', '--memory', default=32, type=int,
                       help='Amount (GB) of GPU RAM. (default: 12)')
     args.add_argument('--chunk_size', default=None, type=int,
@@ -804,6 +806,9 @@ none: give label based on the mean probability of read pair.
     else:
         config_file = args.config
     config = ConfigParser.from_json(config_file)
+    if args.seed:
+        torch.manual_seed(args.seed)
+
     seq_pred = Predictor(config, args)
     seq_pred.load_model()
     seq_pred.detect()

--- a/ribodetector/detect_cpu.py
+++ b/ribodetector/detect_cpu.py
@@ -797,7 +797,8 @@ none: give label based on the mean probability of read pair.
 
     args.add_argument('-t', '--threads', default=20, type=int,
                       help='Number of threads to use. (default: 20)')
-
+    args.add_argument('-s', '--seed', default=None, type=int,
+                      help='Random seed.')
     args.add_argument('--chunk_size', default=None, type=int,
                       help='chunk_size * 1024 reads to load each time. \n{}.'.format(
                           'When chunk_size=1000 and threads=20, consumming ~20G memory, better to be multiples of the number of threads.'))
@@ -813,6 +814,9 @@ none: give label based on the mean probability of read pair.
     else:
         config_file = args.config
     config = ConfigParser.from_json(config_file)
+    
+    if args.seed:
+        onnxruntime.set_seed(args.seed)
 
     os.environ['OMP_NUM_THREADS'] = '1'
     # os.environ['MKL_NUM_THREADS'] = '1'

--- a/ribodetector/detect_cpu.py
+++ b/ribodetector/detect_cpu.py
@@ -815,7 +815,7 @@ none: give label based on the mean probability of read pair.
         config_file = args.config
     config = ConfigParser.from_json(config_file)
     
-    if args.seed:
+    if isinstance(args.seed, int):
         onnxruntime.set_seed(args.seed)
 
     os.environ['OMP_NUM_THREADS'] = '1'


### PR DESCRIPTION
This PR provides the option to set a manual seed from the CLI, for more deterministic runs of ribodetector.
By default, no seed is set.